### PR TITLE
Added is_time_fixed definition

### DIFF
--- a/isimip_qc/models.py
+++ b/isimip_qc/models.py
@@ -32,6 +32,7 @@ class File(object):
 
         self.is_2d = False
         self.is_3d = False
+        self.is_time_fixed = False
 
     @property
     def json(self):


### PR DESCRIPTION
Attempt to solve issue on .../qc-env/lib/python3.9/site-packages/isimip_qc/checks/dimensions.py", line 41, in check_time_dimension
    if not file.is_time_fixed and file.dataset.dimensions.get('time') is None:
AttributeError: 'File' object has no attribute 'is_time_fixed'