### PR TITLE
Add summary functionality

### DIFF
--- a/isimip_qc/main.py
+++ b/isimip_qc/main.py
@@ -86,7 +86,7 @@ def main():
 
     # walk over unchecked files
     for file_path in walk_files(settings.UNCHECKED_PATH):
-        logger.log(CHECKING, settings.CHECKED_PATH)
+        logger.log(CHECKING, settings.UNCHECKED_PATH)
         if file_path.suffix in settings.PATTERN['suffix']:
             file = File(file_path)
             file.open_log()

--- a/isimip_qc/main.py
+++ b/isimip_qc/main.py
@@ -86,7 +86,7 @@ def main():
 
     # walk over unchecked files
     for file_path in walk_files(settings.UNCHECKED_PATH):
-        logger.log(CHECKING, settings.UNCHECKED_PATH)
+        logger.log(CHECKING, file_path)
         if file_path.suffix in settings.PATTERN['suffix']:
             file = File(file_path)
             file.open_log()

--- a/isimip_qc/models.py
+++ b/isimip_qc/models.py
@@ -4,7 +4,7 @@ from collections import Counter
 
 import colorlog
 import jsonschema
-from prettytable.colortable import ColorTable, Themes
+from prettytable.colortable import PrettyTable
 
 from .config import settings
 from .utils.datamodel import call_cdo, call_nccopy
@@ -12,6 +12,7 @@ from .utils.files import copy_file, move_file
 from .utils.netcdf import (get_dimensions, get_global_attributes,
                            get_variables, open_dataset_read,
                            open_dataset_write)
+from .utils.logging import SUMMARY
 
 
 class File(object):
@@ -238,15 +239,8 @@ class Summary(object):
             else:
                 self.variables[variable]['count'] += 1
 
-    def print_specifiers(self):
-        title = ColorTable(theme=Themes.OCEAN)
-        title.header = False
-        title.add_row(['Specifier summary'])
-
-        print()
-        print(title)
-
-        table = ColorTable(theme=Themes.OCEAN)
+    def log_specifiers(self):
+        table = PrettyTable()
         table.field_names = ['Identifier', 'Specifier', 'Count']
         table.align['Identifier'] = 'l'
         table.align['Specifier'] = 'l'
@@ -256,18 +250,11 @@ class Summary(object):
             for i, (specifier, count) in enumerate(counter.items()):
                 table.add_row([identifier if i == 0 else '', specifier, count])
 
-        print()
-        print(table)
+        for line in table.get_string().splitlines():
+            colorlog.log(SUMMARY, line)
 
-    def print_variables(self):
-        title = ColorTable(theme=Themes.OCEAN)
-        title.header = False
-        title.add_row(['Variable summary'])
-
-        print()
-        print(title)
-
-        table = ColorTable(theme=Themes.OCEAN)
+    def log_variables(self):
+        table = PrettyTable()
         table.field_names = ['Specifier', 'Sectors', 'Count']
         table.align['Specifier'] = 'l'
         table.align['Long name'] = 'l'
@@ -277,9 +264,9 @@ class Summary(object):
         for specifier, variable in self.variables.items():
             table.add_row([specifier, ', '.join(variable.get('sectors')), variable.get('count')])
 
-        print()
-        print(table)
+        for line in table.get_string().splitlines():
+            colorlog.log(SUMMARY, line)
 
-    def print(self):
-        self.print_specifiers()
-        self.print_variables()
+    def log(self):
+        self.log_specifiers()
+        self.log_variables()

--- a/isimip_qc/models.py
+++ b/isimip_qc/models.py
@@ -1,8 +1,10 @@
 import logging
 import shutil
+from collections import Counter
 
 import colorlog
 import jsonschema
+from prettytable.colortable import ColorTable, Themes
 
 from .config import settings
 from .utils.datamodel import call_cdo, call_nccopy
@@ -210,3 +212,74 @@ class File(object):
 
     def move(self):
         move_file(self.abs_path, settings.CHECKED_PATH / self.path)
+
+
+class Summary(object):
+
+    def __init__(self):
+        self.specifiers = {}
+        self.variables = {}
+
+    def update_specifiers(self, specifiers):
+        for identifier, specifier in specifiers.items():
+            if identifier not in self.specifiers:
+                self.specifiers[identifier] = Counter()
+            self.specifiers[identifier][specifier] += 1
+
+    def update_variables(self, variable):
+        if variable is not None:
+            if variable not in self.variables:
+                definition = settings.DEFINITIONS['variable'].get(variable)
+                self.variables[variable] = {
+                    'specifier': variable,
+                    'sectors': definition.get('sectors'),
+                    'count': 1
+                }
+            else:
+                self.variables[variable]['count'] += 1
+
+    def print_specifiers(self):
+        title = ColorTable(theme=Themes.OCEAN)
+        title.header = False
+        title.add_row(['Specifier summary'])
+
+        print()
+        print(title)
+
+        table = ColorTable(theme=Themes.OCEAN)
+        table.field_names = ['Identifier', 'Specifier', 'Count']
+        table.align['Identifier'] = 'l'
+        table.align['Specifier'] = 'l'
+        table.align['Count'] = 'r'
+
+        for identifier, counter in self.specifiers.items():
+            for i, (specifier, count) in enumerate(counter.items()):
+                table.add_row([identifier if i == 0 else '', specifier, count])
+
+        print()
+        print(table)
+
+    def print_variables(self):
+        title = ColorTable(theme=Themes.OCEAN)
+        title.header = False
+        title.add_row(['Variable summary'])
+
+        print()
+        print(title)
+
+        table = ColorTable(theme=Themes.OCEAN)
+        table.field_names = ['Specifier', 'Sectors', 'Count']
+        table.align['Specifier'] = 'l'
+        table.align['Long name'] = 'l'
+        table.align['Sectors'] = 'l'
+        table.align['Count'] = 'r'
+
+        for specifier, variable in self.variables.items():
+            table.add_row([specifier, ', '.join(variable.get('sectors')), variable.get('count')])
+
+        print()
+        print(table)
+
+    def print(self):
+        self.print_specifiers()
+        self.print_variables()

--- a/isimip_qc/utils/logging.py
+++ b/isimip_qc/utils/logging.py
@@ -1,0 +1,7 @@
+import logging as python_logging
+
+CHECKING = 22
+SUMMARY = 21
+
+python_logging.addLevelName(CHECKING, 'CHECKING')
+python_logging.addLevelName(SUMMARY, 'SUMMARY')

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -3,3 +3,4 @@ requests
 jsonschema
 colorlog
 python-dotenv
+prettytable


### PR DESCRIPTION
This PR adds a `--summary` flag, which collects some data about the checked files and then displays it at the end as 2 tables, e.g.:

```
+------------------+---------------+-------+
| Identifier       | Specifier     | Count |
+------------------+---------------+-------+
| model            | classic       |  1387 |
| climate_forcing  | gswp3-w5e5    |  1387 |
| climate_scenario | counterclim   |   568 |
|                  | obsclim       |   819 |
| soc_scenario     | 2015soc       |   568 |
...
+------------------+---------------+-------+
```

and

```
+---------------+----------------------------------------------------------------+-------+
| Specifier     | Sectors                                                        | Count |
+---------------+----------------------------------------------------------------+-------+
| burntarea     | biomes, fire, permafrost                                       |    88 |
| ch4           | permafrost, biomes                                             |     5 |
| cleaf         | biomes, forestry, permafrost                                   |    50 |
| clitterag     | biomes, fire, forestry, permafrost                             |    50 |
...
+---------------+----------------------------------------------------------------+-------+
```

where the sectors are taken from the protocol. This should help with finding additional sectors for models.