### PR TITLE
Refactor include and exclude command line options ...

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,10 +120,10 @@ optional arguments:
   --log-level LOG_LEVEL
                         Log level (CRITICAL, ERROR, WARN, VRDETAIL, CHECKING, SUMMARY, INFO, or DEBUG)
   --log-path LOG_PATH   base path for the individual log files
-  --include INCLUDE
-                        only include files that match any element of this comma-separated list
-  --exclude EXCLUDE
-                        exclude files that match any element of this comma-separated list
+  --include INCLUDE_LIST
+                        Patterns of files to include. Exclude those that don't match any.
+  --exclude EXCLUDE_LIST
+                        Patterns of files to exclude. Include only those that don't match any.
   -f, --first-file      only process first file found in UNCHECKED_PATH
   -w, --stop-on-warnings
                         stop execution on warnings
@@ -167,8 +167,8 @@ The only mandatory argument is the `schema_path`, which specifies the pattern an
 `INFO`: includes `SUMMARY` and details for successful checks<br>
 `DEBUG`: all the above plus details for some debugging cases.
 * `--log-path LOG_PATH`: Also write the logs to a file where the folder structure below LOG_PATH is taken from UNCHECKED_PATH.
-* `--include INCLUDE` : Provide a comma-separated list of strings to include for the checks if any of them matches the file path or name, e.g. 'daily,dis' will only check `*daily*` or `*discharge*` files while skipping others.
-* `--exclude EXCLUDE` : Provide a comma-separated list of strings to exclude from the checks if any of them matches the file path or name, e.g. 'monthly,histsoc' will skip any `*monthly*` or `*histsoc*` files.
+* `--include INCLUDE_LIST` : Provide a comma-separated list of strings to include for the checks if any of them matches the file path or name, e.g. 'daily,dis' will only check `*daily*` or `*discharge*` files while skipping others.
+* `--exclude EXCLUDE_LIST` : Provide a comma-separated list of strings to exclude from the checks if any of them matches the file path or name, e.g. 'monthly,histsoc' will skip any `*monthly*` or `*histsoc*` files.
 * `-f, --first-file`: Only test the first file found in UNCHECKED_PATH. Useful for revealing issues that may occur on all your files.
 * `-w, --stop-on-warnings`: The tool will stop after the first file where WARNINGs have been identified.
 * `-e, --stop-on-errors`: The tool will stop after the first file where ERRORs have been identified.

--- a/README.md
+++ b/README.md
@@ -120,10 +120,10 @@ optional arguments:
   --log-level LOG_LEVEL
                         Log level (CRITICAL, ERROR, WARN, VRDETAIL, CHECKING, SUMMARY, INFO, or DEBUG)
   --log-path LOG_PATH   base path for the individual log files
-  --include VARIABLES_INCLUDE
-                        include only this comma-separated list of variables
-  --exclude VARIABLES_EXCLUDE
-                        exclude this comma-separated list of variables
+  --include INCLUDE
+                        only include files that match any element of this comma-separated list
+  --exclude EXCLUDE
+                        exclude files that match any element of this comma-separated list
   -f, --first-file      only process first file found in UNCHECKED_PATH
   -w, --stop-on-warnings
                         stop execution on warnings
@@ -167,8 +167,8 @@ The only mandatory argument is the `schema_path`, which specifies the pattern an
 `INFO`: includes `SUMMARY` and details for successful checks<br>
 `DEBUG`: all the above plus details for some debugging cases.
 * `--log-path LOG_PATH`: Also write the logs to a file where the folder structure below LOG_PATH is taken from UNCHECKED_PATH.
-* `--include VARIABLES_INCLUDE` : Provide a comma-separated list of variables to include for the checks.
-* `--exclude VARIABLES_INCLUDE` : Provide a comma-separated list of variables to exclude from the checks.
+* `--include INCLUDE` : Provide a comma-separated list of strings to include for the checks if any of them matches the file path or name, e.g. 'daily,dis' will only check `*daily*` or `*discharge*` files while skipping others.
+* `--exclude EXCLUDE` : Provide a comma-separated list of strings to exclude from the checks if any of them matches the file path or name, e.g. 'monthly,histsoc' will skip any `*monthly*` or `*histsoc*` files.
 * `-f, --first-file`: Only test the first file found in UNCHECKED_PATH. Useful for revealing issues that may occur on all your files.
 * `-w, --stop-on-warnings`: The tool will stop after the first file where WARNINGs have been identified.
 * `-e, --stop-on-errors`: The tool will stop after the first file where ERRORs have been identified.

--- a/isimip_qc/main.py
+++ b/isimip_qc/main.py
@@ -23,7 +23,6 @@ def get_parser():
     # optional
     parser.add_argument('--config-file', dest='config_file',
                         help='File path of the config file')
-
     parser.add_argument('-c', '--copy', dest='copy', action='store_true',
                         help='Copy checked files to CHECKED_PATH if no warnings or errors were found')
     parser.add_argument('-m', '--move', dest='move', action='store_true',
@@ -40,10 +39,14 @@ def get_parser():
                         help='Log level (CRITICAL, ERROR, WARN, VRDETAIL, CHECKING, SUMMARY, INFO, or DEBUG)')
     parser.add_argument('--log-path', dest='log_path',
                         help='base path for the individual log files')
-    parser.add_argument('--include', dest='variables_include',
-                        help='include only this comma-separated list of variables')
-    parser.add_argument('--exclude', dest='variables_exclude',
-                        help='exclude this comma-separated list of variables')
+    # parser.add_argument('--include', dest='variables_include',
+    #                     help='include only this comma-separated list of variables')
+    # parser.add_argument('--exclude', dest='variables_exclude',
+    #                     help='exclude this comma-separated list of variables')
+    parser.add_argument('--include', dest='include_glob', action='append',
+                        help='Glob-style pattern of files to include')
+    parser.add_argument('--exclude', dest='exclude_glob', action='append',
+                        help='Glob-style pattern of files to exclude')
     parser.add_argument('-f', '--first-file', dest='first_file', action='store_true', default=False,
                         help='only process first file found in UNCHECKED_PATH')
     parser.add_argument('-w', '--stop-on-warnings', dest='stop_warn', action='store_true', default=False,
@@ -92,6 +95,17 @@ def main():
     for file_path in walk_files(settings.UNCHECKED_PATH):
         logger.log(CHECKING, file_path)
         if file_path.suffix in settings.PATTERN['suffix']:
+
+            if settings.INCLUDE_GLOB:
+                if not all([file_path.match(glob) for glob in settings.INCLUDE_GLOB]):
+                    logger.info('skipped by include option')
+                    continue
+
+            if settings.EXCLUDE_GLOB:
+                if any([file_path.match(glob) for glob in settings.EXCLUDE_GLOB]):
+                    logger.info('skipped by exclude option')
+                    continue
+
             file = File(file_path)
             file.open_log()
 
@@ -100,18 +114,17 @@ def main():
             file.match()
 
             if file.matched:
+                # if settings.VARIABLES_INCLUDE is not None and file.specifiers['variable'] not in settings.VARIABLES_INCLUDE.split(sep=','):
+                #     logger.info('skipped by include option')
+                #     file.close_log()
+                #     file.close_dataset()
+                #     continue
 
-                if settings.VARIABLES_INCLUDE is not None and file.specifiers['variable'] not in settings.VARIABLES_INCLUDE.split(sep=','):
-                    logger.info('skipped by include option')
-                    file.close_log()
-                    file.close_dataset()
-                    continue
-
-                if settings.VARIABLES_EXCLUDE is not None and file.specifiers['variable'] in settings.VARIABLES_EXCLUDE.split(sep=','):
-                    logger.info('skipped by exclude option')
-                    file.close_log()
-                    file.close_dataset()
-                    continue
+                # if settings.VARIABLES_EXCLUDE is not None and file.specifiers['variable'] in settings.VARIABLES_EXCLUDE.split(sep=','):
+                #     logger.info('skipped by exclude option')
+                #     file.close_log()
+                #     file.close_dataset()
+                #     continue
 
                 for check in checks:
                     if not settings.CHECK or check.__name__ == settings.CHECK:

--- a/isimip_qc/main.py
+++ b/isimip_qc/main.py
@@ -39,10 +39,10 @@ def get_parser():
                         help='Log level (CRITICAL, ERROR, WARN, VRDETAIL, CHECKING, SUMMARY, INFO, or DEBUG)')
     parser.add_argument('--log-path', dest='log_path',
                         help='base path for the individual log files')
-    parser.add_argument('--include', dest='include_glob',
-                        help='Glob-style pattern of files to include')
-    parser.add_argument('--exclude', dest='exclude_glob',
-                        help='Glob-style pattern of files to exclude')
+    parser.add_argument('--include', dest='include_list',
+                        help='Patterns of files to include. Exclude those that don\'t match any.')
+    parser.add_argument('--exclude', dest='exclude_list',
+                        help='Patterns of files to exclude. Include only those that don\'t match any.')
     parser.add_argument('-f', '--first-file', dest='first_file', action='store_true', default=False,
                         help='only process first file found in UNCHECKED_PATH')
     parser.add_argument('-w', '--stop-on-warnings', dest='stop_warn', action='store_true', default=False,
@@ -91,13 +91,13 @@ def main():
     for file_path in walk_files(settings.UNCHECKED_PATH):
         logger.log(CHECKING, file_path)
 
-        if settings.INCLUDE_GLOB:
-            if not any([glob in str(file_path) for glob in settings.INCLUDE_GLOB.split(',')]):
+        if settings.INCLUDE_LIST:
+            if not any([string in str(file_path) for string in settings.INCLUDE_LIST.split(',')]):
                 logger.log(CHECKING, ' skipped by include option')
                 continue
 
-        if settings.EXCLUDE_GLOB:
-            if any([glob in str(file_path) for glob in settings.EXCLUDE_GLOB.split(',')]):
+        if settings.EXCLUDE_LIST:
+            if any([string in str(file_path) for string in settings.EXCLUDE_LIST.split(',')]):
                 logger.log(CHECKING, ' skipped by exclude option')
                 continue
 


### PR DESCRIPTION
...  to be lists of glob-style patterns. This should work then:

```
isimip-qc ISIMIP2a/OutputData/agriculture --include '*_annual_*' --exclude '*_qtot_*'
```

Filtering is done *before* matching the ISIMIP patterns.