### PR TITLE
'any' string to match include lists

### DIFF
--- a/isimip_qc/main.py
+++ b/isimip_qc/main.py
@@ -136,7 +136,7 @@ def main():
 
 def check_file_path(file_path):
     if settings.INCLUDE:
-        if not include_path(settings.INCLUDE, file_path, 'all'):
+        if not include_path(settings.INCLUDE, file_path, 'any'):
             logger.info('%s skipped by include option.', file_path)
             return False
 

--- a/isimip_qc/main.py
+++ b/isimip_qc/main.py
@@ -136,7 +136,7 @@ def main():
 
 def check_file_path(file_path):
     if settings.INCLUDE:
-        if not include_path(settings.INCLUDE, file_path, 'any'):
+        if not include_path(settings.INCLUDE, file_path):
             logger.info('%s skipped by include option.', file_path)
             return False
 


### PR DESCRIPTION
This patch brings back the old well preferred behavior to for example only work on lists of certain variables or experiments. `all` asks to have every list element in a file path