### PR TITLE
Protocol integration

### DIFF
--- a/isimip_qc/checks/dimensions.py
+++ b/isimip_qc/checks/dimensions.py
@@ -6,9 +6,6 @@ def check_lon_dimension(file):
     climate_forcing = file.specifiers.get('climate_forcing')
     sens_scenario = file.specifiers.get('sens_scenario')
 
-    if settings.SECTOR in ('marine-fishery_regional', 'water_regional', 'lakes_local', 'forestry'):
-        return
-
     # get dimension from the dataset
     lon_dim = file.dataset.dimensions.get('lon')
     if lon_dim is None:
@@ -20,13 +17,22 @@ def check_lon_dimension(file):
 
     # overwrite for special climate forcings defined in the protocol
     grid_info = settings.DEFINITIONS['climate_forcing'].get(climate_forcing, {}).get('grid', {})
-    if 'lon' in grid_info:
-        lon_size = grid_info['lon'].get('size', {}).get('default', lon_size)
-        lon_size = grid_info['lon'].get('size', {}).get(sens_scenario, lon_size)
+    if grid_info:
+        lon_size = grid_info.get('lon').get('size', {}).get('default', lon_size)
+        lon_size = grid_info.get('lon').get('size', {}).get(sens_scenario, lon_size)
+
+    # overwrite for special sectors defined in the protocol
+    sector_grid = settings.DEFINITIONS['sector'].get(settings.SECTOR, {}).get('grid')
+    if sector_grid:
+        if sector_grid.get('lon', {}).get('size') is False:
+            return
+        lon_size = sector_grid.get('lon', {}).get('size', lon_size)
 
     # overwrite for special models defined in the protocol
     model_grid = settings.DEFINITIONS['model'].get(model, {}).get('grid')
     if model_grid:
+        if model_grid.get('lon', {}).get('size') is False:
+            return
         lon_size = model_grid.get('lon', {}).get('size', lon_size)
 
     actual = lon_dim.size
@@ -41,9 +47,6 @@ def check_lat_dimension(file):
     climate_forcing = file.specifiers.get('climate_forcing')
     sens_scenario = file.specifiers.get('sens_scenario')
 
-    if settings.SECTOR in ('marine-fishery_regional', 'water_regional', 'lakes_local', 'forestry'):
-        return
-
     # get dimension from the dataset
     lat_dim = file.dataset.dimensions.get('lat')
     if lat_dim is None:
@@ -55,13 +58,22 @@ def check_lat_dimension(file):
 
     # overwrite for special climate forcings defined in the protocol
     grid_info = settings.DEFINITIONS['climate_forcing'].get(climate_forcing, {}).get('grid', {})
-    if 'lat' in grid_info:
+    if grid_info:
         lat_size = grid_info['lat'].get('size', {}).get('default', lat_size)
         lat_size = grid_info['lat'].get('size', {}).get(sens_scenario, lat_size)
+
+    # overwrite for special sectors defined in the protocol
+    sector_grid = settings.DEFINITIONS['sector'].get(settings.SECTOR, {}).get('grid')
+    if sector_grid:
+        if sector_grid.get('lat', {}).get('size') is False:
+            return
+        lat_size = sector_grid.get('lat', {}).get('size', lat_size)
 
     # overwrite for special models defined in the protocol
     model_grid = settings.DEFINITIONS['model'].get(model, {}).get('grid')
     if model_grid:
+        if model_grid.get('lat', {}).get('size') is False:
+            return
         lat_size = model_grid.get('lat', {}).get('size', lat_size)
 
     actual = lat_dim.size

--- a/isimip_qc/checks/dimensions.py
+++ b/isimip_qc/checks/dimensions.py
@@ -20,11 +20,9 @@ def check_lon_dimension(file):
 
     # overwrite for special climate forcings defined in the protocol
     grid_info = settings.DEFINITIONS['climate_forcing'].get(climate_forcing, {}).get('grid', {})
-    if 'lon_size' in grid_info:
-        lon_size = (
-            grid_info.get('lon_size', {})
-                     .get(sens_scenario, grid_info.get('lon_size', {}).get('default', lon_size))
-        )
+    if 'lon' in grid_info:
+        lon_size = grid_info['lon'].get('size', {}).get('default', lon_size)
+        lon_size = grid_info['lon'].get('size', {}).get(sens_scenario, lon_size)
 
     # overwrite for special models defined in the protocol
     model_grid = settings.DEFINITIONS['model'].get(model, {}).get('grid')
@@ -57,11 +55,9 @@ def check_lat_dimension(file):
 
     # overwrite for special climate forcings defined in the protocol
     grid_info = settings.DEFINITIONS['climate_forcing'].get(climate_forcing, {}).get('grid', {})
-    if 'lat_size' in grid_info:
-        lat_size = (
-            grid_info.get('lat_size', {})
-                     .get(sens_scenario, grid_info.get('lat_size', {}).get('default', lat_size))
-        )
+    if 'lat' in grid_info:
+        lat_size = grid_info['lat'].get('size', {}).get('default', lat_size)
+        lat_size = grid_info['lat'].get('size', {}).get(sens_scenario, lat_size)
 
     # overwrite for special models defined in the protocol
     model_grid = settings.DEFINITIONS['model'].get(model, {}).get('grid')

--- a/isimip_qc/checks/dimensions.py
+++ b/isimip_qc/checks/dimensions.py
@@ -9,26 +9,27 @@ def check_lon_dimension(file):
     if settings.SECTOR in ('marine-fishery_regional', 'water_regional', 'lakes_local', 'forestry'):
         return
 
-    ds = file.dataset
-    dims = ds.dimensions
-    lon_dim = dims.get('lon')
+    # get dimension from the dataset
+    lon_dim = file.dataset.dimensions.get('lon')
     if lon_dim is None:
         file.error('Longitude dimension "lon" is missing.')
         return
 
-    if model == 'dbem':
-        lon_size = 720
-    else:
-        lon_size = settings.DEFINITIONS['dimensions'].get('lon')['size']
+    # get size from the protocol
+    lon_size = settings.DEFINITIONS['dimensions'].get('lon')['size']
 
-    # pick longitude size if available from data set definition
-    cf_def = settings.DEFINITIONS['climate_forcing'].get(climate_forcing, {})
-    grid_info = cf_def.get('grid', {})
+    # overwrite for special climate forcings defined in the protocol
+    grid_info = settings.DEFINITIONS['climate_forcing'].get(climate_forcing, {}).get('grid', {})
     if 'lon_size' in grid_info:
         lon_size = (
             grid_info.get('lon_size', {})
                      .get(sens_scenario, grid_info.get('lon_size', {}).get('default', lon_size))
         )
+
+    # overwrite for special models defined in the protocol
+    model_grid = settings.DEFINITIONS['model'].get(model, {}).get('grid')
+    if model_grid:
+        lon_size = model_grid.get('lon', {}).get('size', lon_size)
 
     actual = lon_dim.size
     if lon_size != actual:
@@ -45,25 +46,27 @@ def check_lat_dimension(file):
     if settings.SECTOR in ('marine-fishery_regional', 'water_regional', 'lakes_local', 'forestry'):
         return
 
-    ds = file.dataset
-    dims = ds.dimensions
-    lat_dim = dims.get('lat')
+    # get dimension from the dataset
+    lat_dim = file.dataset.dimensions.get('lat')
     if lat_dim is None:
         file.error('Latitude dimension "lat" is missing.')
         return
 
-    if model == 'dbem':
-        lat_size = 360
-    else:
-        lat_size = settings.DEFINITIONS['dimensions'].get('lat')['size']
+    # get size from the protocol
+    lat_size = settings.DEFINITIONS['dimensions'].get('lat')['size']
 
-    cf_def = settings.DEFINITIONS['climate_forcing'].get(climate_forcing, {})
-    grid_info = cf_def.get('grid', {})
+    # overwrite for special climate forcings defined in the protocol
+    grid_info = settings.DEFINITIONS['climate_forcing'].get(climate_forcing, {}).get('grid', {})
     if 'lat_size' in grid_info:
         lat_size = (
             grid_info.get('lat_size', {})
                      .get(sens_scenario, grid_info.get('lat_size', {}).get('default', lat_size))
         )
+
+    # overwrite for special models defined in the protocol
+    model_grid = settings.DEFINITIONS['model'].get(model, {}).get('grid')
+    if model_grid:
+        lat_size = model_grid.get('lat', {}).get('size', lat_size)
 
     actual = lat_dim.size
     if lat_size != actual:

--- a/isimip_qc/checks/variables/latlon.py
+++ b/isimip_qc/checks/variables/latlon.py
@@ -99,14 +99,11 @@ def check_latlon_variable(file):
                              .get(sens_scenario, grid_info.get('lon_max', {}).get('default', maximum))
                 )
 
-        # overwrite for special cases not defined in the protocol
-        if model == 'dbem':
-            if variable == 'lat':
-                minimum = -89.75
-                maximum = 89.75
-            elif variable == 'lon':
-                minimum = -179.75
-                maximum = 179.75
+        # overwrite for special cases defined in the protocol
+        model_grid = settings.DEFINITIONS['model'].get(model, {}).get('grid')
+        if model_grid:
+            minimum = model_grid.get(variable, {}).get('min', minimum)
+            maximum = model_grid.get(variable, {}).get('max', maximum)
 
         # use first and last element which is sufficient for monotonic lat/lon
         try:

--- a/isimip_qc/checks/variables/latlon.py
+++ b/isimip_qc/checks/variables/latlon.py
@@ -69,39 +69,38 @@ def check_latlon_variable(file):
                           'args': (file, variable, 'units', units)
                       })
 
-        if settings.SECTOR in ('marine-fishery_regional', 'water_regional', 'lakes_local', 'forestry'):
-            continue
-
-        # pick lat/lon ranges if available from dimensions definition
+        # get lat/lon ranges from the protocol
         minimum = var_definition.get('minimum')
         maximum = var_definition.get('maximum')
 
-        # overwrite lat/lon ranges if available from climate forcing definition
-        cf_def = settings.DEFINITIONS['climate_forcing'].get(climate_forcing, {})
-        grid_info = cf_def.get('grid', {})
+        # overwrite lat/lon ranges for special climate forcings defined in the protocol
+        grid_info = settings.DEFINITIONS['climate_forcing'].get(climate_forcing, {}).get('grid', {})
         if grid_info:
-            if variable == 'lat':
-                minimum = (
-                    grid_info.get('lat_min', {})
-                             .get(sens_scenario, grid_info.get('lat_min', {}).get('default', minimum))
-                )
-                maximum = (
-                    grid_info.get('lat_max', {})
-                             .get(sens_scenario, grid_info.get('lat_max', {}).get('default', maximum))
-                )
-            else:
-                minimum = (
-                    grid_info.get('lon_min', {})
-                             .get(sens_scenario, grid_info.get('lon_min', {}).get('default', minimum))
-                )
-                maximum = (
-                    grid_info.get('lon_max', {})
-                             .get(sens_scenario, grid_info.get('lon_max', {}).get('default', maximum))
-                )
+            minimum = grid_info.get(variable, {}).get('min', {}).get('default', minimum)
+            minimum = grid_info.get(variable, {}).get('min', {}).get(sens_scenario, minimum)
 
-        # overwrite for special cases defined in the protocol
+            maximum = grid_info.get(variable, {}).get('max', {}).get('default', maximum)
+            maximum = grid_info.get(variable, {}).get('max', {}).get(sens_scenario, maximum)
+
+        # overwrite lat/lon ranges for special sectors defined in the protocol
+        sector_grid = settings.DEFINITIONS['sector'].get(settings.SECTOR, {}).get('grid')
+        if sector_grid:
+            if (
+                sector_grid.get(variable, {}).get('min') is False or
+                sector_grid.get(variable, {}).get('max') is False
+            ):
+                return
+            minimum = grid_info.get(variable, {}).get('min', minimum)
+            maximum = grid_info.get(variable, {}).get('max', maximum)
+
+        # overwrite lat/lon ranges for special cases defined in the protocol
         model_grid = settings.DEFINITIONS['model'].get(model, {}).get('grid')
         if model_grid:
+            if (
+                model_grid.get(variable, {}).get('min') is False or
+                model_grid.get(variable, {}).get('max') is False
+            ):
+                return
             minimum = model_grid.get(variable, {}).get('min', minimum)
             maximum = model_grid.get(variable, {}).get('max', maximum)
 

--- a/isimip_qc/checks/variables/time_resolution.py
+++ b/isimip_qc/checks/variables/time_resolution.py
@@ -4,9 +4,6 @@ from isimip_qc.config import settings
 
 
 def check_time_resolution(file):
-    if settings.SECTOR == 'agriculture':
-        return
-
     if file.is_time_fixed:
         return
 
@@ -15,6 +12,11 @@ def check_time_resolution(file):
     time = variables.get('time')
     time_definition = settings.DEFINITIONS['dimensions'].get('time')
     time_resolution = file.specifiers.get('time_step')
+    time_resolution_definition = settings.DEFINITIONS['time_step'].get(time_resolution)
+
+    # skip check for time resolution, e.g. for agriculture
+    if time_resolution_definition.get('check') is False:
+        return
 
     # get attributes defensively without exception-driven control flow
     time_units = getattr(time, 'units', None)

--- a/isimip_qc/checks/variables/var.py
+++ b/isimip_qc/checks/variables/var.py
@@ -55,10 +55,11 @@ def check_variable(file):
                     .get(sens_scenario, grid_info.get('lon_size', {}).get('default'))
                 )
 
-            # overwrite for special cases not defined in the protocol
-            if model == 'dbem':
-                lat_size = 360
-                lon_size = 720
+            # overwrite for special cases defined in the protocol
+            model_grid = settings.DEFINITIONS['model'].get(model, {}).get('grid')
+            if model_grid:
+                lat_size = model_grid.get('lat', {}).get('size', lat_size)
+                lon_size = model_grid.get('lon', {}).get('size', lon_size)
 
             if file.is_2d:
                 if chunking[0] != 1 or chunking[1] != lat_size or chunking[2] != lon_size:

--- a/isimip_qc/checks/variables/var.py
+++ b/isimip_qc/checks/variables/var.py
@@ -205,12 +205,17 @@ def check_variable(file):
                                ' when variable is created.', name, file.variable_name)
 
         # check valid range
-        if settings.SECTOR == 'agriculture':
-            return
-
         if isinstance(settings.MINMAX, (int, float)) and not isinstance(settings.MINMAX, bool) and settings.MINMAX >= 0:
             if file.is_time_fixed:
-                file.warning('Valid range test for fixed data not yet implemented')
+                file.warning('Valid range test for fixed data not yet implemented.')
+                return
+
+            # skip valid range check for special sectors
+            if (
+                settings.DEFINITIONS['sector'].get(settings.SECTOR, {}).get('valid_min') is False or
+                settings.DEFINITIONS['sector'].get(settings.SECTOR, {}).get('valid_max') is False
+            ):
+                file.warning('Skip valid range test for "%s" sector.', settings.SECTOR)
                 return
 
             valid_min = definition.get('valid_min')

--- a/isimip_qc/checks/variables/var.py
+++ b/isimip_qc/checks/variables/var.py
@@ -36,30 +36,44 @@ def check_variable(file):
         chunking = variable.chunking()
 
         if chunking:
-            # pick lat/lon sizes from dimensions definition
-            if settings.SECTOR in ['marine-fishery_regional', 'water_regional', 'lakes_local', 'forestry']:
-                lat_size = variables.get('lat').size
-                lon_size = variables.get('lon').size
-            else:
-                lat_size = settings.DEFINITIONS['dimensions'].get('lat')['size']
-                lon_size = settings.DEFINITIONS['dimensions'].get('lon')['size']
-            # overwrite lat/lon ranges if available from climate forcing definition
-            if 'grid' in settings.DEFINITIONS['climate_forcing'].get(climate_forcing):
-                grid_info = settings.DEFINITIONS['climate_forcing'].get(climate_forcing)['grid']
-                lat_size = (
-                    grid_info.get('lat_size', {})
-                    .get(sens_scenario, grid_info.get('lat_size', {}).get('default'))
-                )
-                lon_size = (
-                    grid_info.get('lon_size', {})
-                    .get(sens_scenario, grid_info.get('lon_size', {}).get('default'))
-                )
+            # get sizes from the protocol
+            lat_size = settings.DEFINITIONS['dimensions'].get('lat')['size']
+            lon_size = settings.DEFINITIONS['dimensions'].get('lon')['size']
 
-            # overwrite for special cases defined in the protocol
+            # overwrite for special climate forcings defined in the protocol
+            grid_info = settings.DEFINITIONS['climate_forcing'].get(climate_forcing, {}).get('grid', {})
+            if grid_info:
+                lat_size = grid_info['lat'].get('size', {}).get('default', lat_size)
+                lat_size = grid_info['lat'].get('size', {}).get(sens_scenario, lat_size)
+
+                lon_size = grid_info['lon'].get('size', {}).get('default', lon_size)
+                lon_size = grid_info['lon'].get('size', {}).get(sens_scenario, lon_size)
+
+            # overwrite for special sectors defined in the protocol
+            sector_grid = settings.DEFINITIONS['sector'].get(settings.SECTOR, {}).get('grid')
+            if sector_grid:
+                if sector_grid.get('lat', {}).get('size') is False:
+                    lat_size = variables.get('lat').size
+                else:
+                    lat_size = sector_grid.get('lat', {}).get('size', lat_size)
+
+                if sector_grid.get('lat', {}).get('size') is False:
+                    lon_size = variables.get('lon').size
+                else:
+                    lon_size = sector_grid.get('lon', {}).get('size') or lon_size
+
+            # overwrite for special models defined in the protocol
             model_grid = settings.DEFINITIONS['model'].get(model, {}).get('grid')
             if model_grid:
-                lat_size = model_grid.get('lat', {}).get('size', lat_size)
-                lon_size = model_grid.get('lon', {}).get('size', lon_size)
+                if model_grid.get('lat', {}).get('size') is False:
+                    lat_size = variables.get('lat').size
+                else:
+                    lat_size = model_grid.get('lat', {}).get('size', lat_size)
+
+                if model_grid.get('lat', {}).get('size') is False:
+                    lon_size = variables.get('lon').size
+                else:
+                    lon_size = model_grid.get('lon', {}).get('size') or lon_size
 
             if file.is_2d:
                 if chunking[0] != 1 or chunking[1] != lat_size or chunking[2] != lon_size:


### PR DESCRIPTION
This PR moves hardcoded information to the protocol. This affects:

* `check_lon_dimension`
* `check_lat_dimension`
* `check_latlon_variable`
* `check_variable`
* `check_time_resolution`

Models and sectors can now have a `grid` property to describe deviations from the default grid, e.g.:

```yaml
- specifier: marine-fishery_regional
  ...
  grid:
    lat:
      min: false
      max: false
      size: 1
    lon:
      min: false
      max: false
      size: 1
```

where `false` means: "do not check", or

```yaml
- specifier: dbem
  title: DBEM
  grid:
    lat:
      min: -89.75
      max: 89.75
      size: 360
    lon:
      min: -179.75
      max: 179.75
      size: 720
```

The `grid` property for `climate_forcing` was refactored (slightly) for consitency.

Also, `time_step` gets a `check: False` property to exclude `monthly-gs` and `annual-gs` from the time resolution check.

Finally, sectors can specify `valid_min: false` and/or `valid_max: false` to skip the `--minmax` checks.



