### PR TITLE
Add setup_env to main

### DIFF
--- a/isimip_qc/main.py
+++ b/isimip_qc/main.py
@@ -2,7 +2,7 @@ import logging
 import sys
 from pathlib import Path
 
-from isimip_utils.cli import ArgumentParser, parse_list, parse_locations, parse_path, setup_logs
+from isimip_utils.cli import ArgumentParser, parse_list, parse_locations, parse_path, setup_env, setup_logs
 from isimip_utils.exceptions import NotFound
 from isimip_utils.utils import exclude_path, include_path
 
@@ -81,6 +81,8 @@ def main():
                         help='copy or move files despite errors')
     parser.add_argument('-V', '--version', action='version',
                         version=VERSION)
+
+    setup_env()
 
     args = parser.parse_args()
 


### PR DESCRIPTION
`setup_env` was missing from `main`. Now, creating a `.env` with e.g. 

```
ISIMIP_PROTOCOL_LOCATIONS=~/code/isimip/isimip-protocol-3
ISIMIP_LOG_LEVEL=INFO
```

should work. Everything else should not change.