### PR TITLE
Add parse_schema_path for validation

### DIFF
--- a/isimip_qc/main.py
+++ b/isimip_qc/main.py
@@ -24,7 +24,6 @@ def main():
     # mandatory
     parser.add_argument('schema_path', type=parse_schema_path,
                         help='ISIMIP schema_path, e.g. ISIMIP3a/OutputData/water_global')
-    parser.add_argument('schema_path', help='ISIMIP schema_path, e.g. ISIMIP3a/OutputData/water_global')
 
     # optional
     parser.add_argument('-c', '--copy', dest='copy', action='store_true',

--- a/isimip_qc/main.py
+++ b/isimip_qc/main.py
@@ -11,6 +11,7 @@ from .checks import checks
 from .config import settings
 from .exceptions import FileCritical, FileError, FileWarning
 from .models import File, Summary
+from .utils.cli import parse_schema_path
 from .utils.files import walk_files
 from .utils.logging import CHECKING
 
@@ -21,6 +22,8 @@ def main():
     parser = ArgumentParser(prog='isimip-qc', description='Check ISIMIP files for matching protocol definitions')
 
     # mandatory
+    parser.add_argument('schema_path', type=parse_schema_path,
+                        help='ISIMIP schema_path, e.g. ISIMIP3a/OutputData/water_global')
     parser.add_argument('schema_path', help='ISIMIP schema_path, e.g. ISIMIP3a/OutputData/water_global')
 
     # optional

--- a/isimip_qc/utils/cli.py
+++ b/isimip_qc/utils/cli.py
@@ -1,0 +1,13 @@
+import argparse
+import re
+from pathlib import Path
+
+
+def parse_schema_path(path):
+    if not re.match(r'^[A-Za-z0-9/_-]+$', path):
+        raise argparse.ArgumentTypeError('must only contain letters, numbers, underscores, hyphens and slashes.')
+
+    path = Path(path)
+    if path.is_absolute():
+        raise argparse.ArgumentTypeError('must not be an absolute path.')
+    return path


### PR DESCRIPTION
This PR adds a validation for the `schema_path` argument to ensure it contains only letters, numbers, underscores, hyphens and slashes, and that it is not an absolute path.