### PR TITLE
Accept the corrected calendar key in time check

### DIFF
--- a/isimip_qc/checks/variables/time.py
+++ b/isimip_qc/checks/variables/time.py
@@ -73,8 +73,6 @@ def check_time_variable(file):
 
     # check calendars
     calendars = time_definition.get('calendars_daily')
-    if calendars is None:
-        calendars = time_definition.get('calenders_daily', [])
     cur_cal = getattr(time, 'calendar', None)
     if cur_cal not in calendars:
         file.error('"calendar" attribute for "time" is "%s". Must be one of "%s".', cur_cal, calendars)

--- a/isimip_qc/checks/variables/time.py
+++ b/isimip_qc/checks/variables/time.py
@@ -72,7 +72,9 @@ def check_time_variable(file):
         file.info('Valid time unit found (%s)', cur_units)
 
     # check calendars
-    calendars = time_definition.get('calenders_daily', [])
+    calendars = time_definition.get('calendars_daily')
+    if calendars is None:
+        calendars = time_definition.get('calenders_daily', [])
     cur_cal = getattr(time, 'calendar', None)
     if cur_cal not in calendars:
         file.error('"calendar" attribute for "time" is "%s". Must be one of "%s".', cur_cal, calendars)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,4 +91,4 @@ ERRORs = "ERRORs"
 WARNINGs = "WARNINGs"
 criticals = "criticals"
 has_criticals = "has_criticals"
-calenders_daily = "calenders_daily"  # TODO: remove when isimip-protocol-3 is fixed
+calenders_daily = "calenders_daily"  # Legacy protocol key kept for backward compatibility

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,4 +91,3 @@ ERRORs = "ERRORs"
 WARNINGs = "WARNINGs"
 criticals = "criticals"
 has_criticals = "has_criticals"
-calenders_daily = "calenders_daily"  # Legacy protocol key kept for backward compatibility


### PR DESCRIPTION
Fixes a compatibility issue between current protocol definitions and the QC time calendar check.
The QC tool now reads the corrected key first and falls back to the historical spelling.