### PR TITLE
Adjust to sample data from forestry sector

### DIFF
--- a/isimip_qc/checks/3d.py
+++ b/isimip_qc/checks/3d.py
@@ -43,12 +43,17 @@ def check_3d(file):
         )
 
     # Number of expected dimensions
-    if 'dimensions' in definition:
-        definition_dim_len = len(definition['dimensions'])
-        dims_expected = str(definition['dimensions']).replace("'", '')
+    sector_default_dimensions = settings.DEFINITIONS['sector'][settings.SECTOR].get('default_dimensions')
+    if sector_default_dimensions:
+        definition_dim_len = len(sector_default_dimensions)
+        dims_expected = sector_default_dimensions
     else:
-        definition_dim_len = 3
-        dims_expected = '[time, lat, lon]'
+        if 'dimensions' in definition:
+            definition_dim_len = len(definition['dimensions'])
+            dims_expected = str(definition['dimensions']).replace("'", '')
+        else:
+            definition_dim_len = 3
+            dims_expected = '[time, lat, lon]'
 
     # detect 2d or 3d data: here we treat [time, lat, lon] as 3 dims (2D data),
     # and an extra vertical dimension yields 4 dims (3D data).
@@ -60,6 +65,8 @@ def check_3d(file):
                 'File has fixed data but more than 2 dimensions. Remove "time" dimension if present.',
             )
         return
+    elif file.dim_len == 2:
+        file.is_1d = True
     elif file.dim_len == 3:
         file.is_2d = True
     elif file.dim_len == 4:

--- a/isimip_qc/checks/dimensions.py
+++ b/isimip_qc/checks/dimensions.py
@@ -3,6 +3,10 @@ from ..utils.grid import update_grid_value
 
 
 def check_lon_dimension(file):
+    sector_default_dimensions = tuple(settings.DEFINITIONS['sector'][settings.SECTOR].get('default_dimensions'))
+    if 'lon' not in sector_default_dimensions:
+        return
+
     # get dimension from the dataset
     lon_dim = file.dataset.dimensions.get('lon')
     if lon_dim is None:
@@ -23,6 +27,9 @@ def check_lon_dimension(file):
 
 
 def check_lat_dimension(file):
+    sector_default_dimensions = tuple(settings.DEFINITIONS['sector'][settings.SECTOR].get('default_dimensions'))
+    if 'lat' not in sector_default_dimensions:
+        return
     # get dimension from the dataset
     lat_dim = file.dataset.dimensions.get('lat')
     if lat_dim is None:
@@ -60,15 +67,22 @@ def check_dimensions(file):
     variable = file.dataset.variables.get(file.variable_name)
     dims = variable.dimensions
 
-    if file.is_time_fixed:
-        expected = ('lat', 'lon')
-    elif file.is_2d:
-        expected = ('time', 'lat', 'lon')
-    elif file.is_3d:
-        expected = ('time', file.dim_vertical, 'lat', 'lon')
+    sector_default_dimensions = tuple(settings.DEFINITIONS['sector'][settings.SECTOR].get('default_dimensions'))
+
+    if sector_default_dimensions:
+        expected = sector_default_dimensions
     else:
-        file.error('Variable "%s" neither holds 2d or 3d data. (dim=%s)', file.variable_name, file.dim_len)
-        return
+        if file.is_time_fixed:
+            expected = ('lat', 'lon')
+        elif file.is_1d:
+            expected = ('time', 'generic')
+        elif file.is_2d:
+            expected = ('time', 'lat', 'lon')
+        elif file.is_3d:
+            expected = ('time', file.dim_vertical, 'lat', 'lon')
+        else:
+            file.error('Variable "%s" neither holds 2d or 3d data. (dim=%s)', file.variable_name, file.dim_len)
+            return
 
     if dims != expected:
         file.error('Dimension order for variable "%s" is %s. Should be %s.', file.variable_name, dims, expected)

--- a/isimip_qc/checks/variables/var.py
+++ b/isimip_qc/checks/variables/var.py
@@ -66,13 +66,19 @@ def check_variable(file):
 
         # check dimensions
         definition_dimensions = tuple(definition.get('dimensions', []))
+        sector_default_dimensions = tuple(settings.DEFINITIONS['sector'][settings.SECTOR].get('default_dimensions'))
 
-        if file.is_time_fixed:
-            default_dimensions = ('lat', 'lon')
-        if file.is_2d:
-            default_dimensions = ('time', 'lat', 'lon')
-        elif file.is_3d:
-            default_dimensions = ('time', file.dim_vertical, 'lat', 'lon')
+        if sector_default_dimensions:
+            default_dimensions = sector_default_dimensions
+        else:
+            if file.is_time_fixed:
+                default_dimensions = ('lat', 'lon')
+            if file.is_1d:
+                default_dimensions = ('time', 'generic')
+            if file.is_2d:
+                default_dimensions = ('time', 'lat', 'lon')
+            elif file.is_3d:
+                default_dimensions = ('time', file.dim_vertical, 'lat', 'lon')
 
         if definition_dimensions:
             if variable.dimensions not in [definition_dimensions, default_dimensions]:


### PR DESCRIPTION
Data from the sector will not have classic gridded data but a `plot` dimension while in turn `lat`, `lon` and the `plotID` depend on it.