### PR TITLE
Dev/check isimip

### DIFF
--- a/isimip_qc/checks/attributes.py
+++ b/isimip_qc/checks/attributes.py
@@ -13,18 +13,19 @@ def check_isimip_id(file):
         isimip_id = file.dataset.getncattr('isimip_id')
         file.info('Global attribute "isimip_id" found (%s).', isimip_id)
 
-        response = confirm_isimip_id(isimip_id)
-        if response:
-            file.warning(
-                'Global attribute "isimip_id" (%s) already exists in the repository for'
-                ' the path %s.',
-                isimip_id,
-                response[0].get('path'),
-                fix={
-                    'func': fix_set_global_attr,
-                    'args': (file, 'isimip_id', str(uuid.uuid4()))
-                }
-            )
+        if settings.CHECK_ISIMIP_ID:
+            response = confirm_isimip_id(isimip_id)
+            if response:
+                file.warning(
+                    'Global attribute "isimip_id" (%s) already exists in the repository for'
+                    ' the path %s.',
+                    isimip_id,
+                    response[0].get('path'),
+                    fix={
+                        'func': fix_set_global_attr,
+                        'args': (file, 'isimip_id', str(uuid.uuid4()))
+                    }
+                )
     else:
         file.info('Global attribute "isimip_id" not yet set.', fix={
             'func': fix_set_global_attr,

--- a/isimip_qc/checks/attributes.py
+++ b/isimip_qc/checks/attributes.py
@@ -5,12 +5,26 @@ from .. import __version__
 from ..config import settings
 from ..fixes import fix_remove_global_attr, fix_set_global_attr
 from ..utils.contact import match_addrs, match_contact
+from ..utils.repository import confirm_isimip_id
 
 
 def check_isimip_id(file):
     if 'isimip_id' in file.dataset.ncattrs():
         isimip_id = file.dataset.getncattr('isimip_id')
         file.info('Global attribute "isimip_id" found (%s).', isimip_id)
+
+        response = confirm_isimip_id(isimip_id)
+        if response:
+            file.warning(
+                'Global attribute "isimip_id" (%s) already exists in the repository for'
+                ' the path %s.',
+                isimip_id,
+                response[0].get('path'),
+                fix={
+                    'func': fix_set_global_attr,
+                    'args': (file, 'isimip_id', str(uuid.uuid4()))
+                }
+            )
     else:
         file.info('Global attribute "isimip_id" not yet set.', fix={
             'func': fix_set_global_attr,

--- a/isimip_qc/main.py
+++ b/isimip_qc/main.py
@@ -68,6 +68,8 @@ def main():
                         help='skip test for valid experiment combination')
     parser.add_argument('--match-only', dest='match_only', action='store_true', default=False,
                         help='only match the file name and skip all other checks')
+    parser.add_argument('--check-isimip-id', dest='check_isimip_id', action='store_true', default=False,
+                        help='check if the isimip_id is already used on the ISIMIP Repository')
     parser.add_argument('-r', '--minmax', dest='minmax', const=10, nargs='?', type=int,
                         help='test values for valid range (slow). MINMAX denotes the length of the ordered top'
                         ' list of outliers')

--- a/isimip_qc/main.py
+++ b/isimip_qc/main.py
@@ -39,6 +39,9 @@ def main():
     parser.add_argument('--protocol-location', dest='protocol_locations', type=parse_locations,
                         default='https://protocol.isimip.org https://protocol2.isimip.org',
                         help='URL or file path to the protocol when different from official repository')
+    parser.add_argument('--data-url', dest='data_url', type=lambda p: p.rstrip('/'),
+                        default='https://data.isimip.org',
+                        help='URL of the ISIMIP repository [default: https://data.isimip.org/]')
     parser.add_argument('--log-level', dest='log_level', default='CHECKING', type=lambda s: s.upper(),
                         help='log level (CRITICAL, ERROR, WARN, CHECKING, INFO, or DEBUG) [default: CHECKING]')
     parser.add_argument('--show-time', dest='show_time', action='store_true', default=False,

--- a/isimip_qc/utils/repository.py
+++ b/isimip_qc/utils/repository.py
@@ -1,0 +1,9 @@
+import requests
+
+from isimip_qc.config import settings
+
+
+def confirm_isimip_id(isimip_id):
+    response = requests.post(f'{settings.DATA_URL}/api/v1/ids/', json=[str(isimip_id)])
+    response.raise_for_status()
+    return response.json()


### PR DESCRIPTION
This PR adds a check to confirm that a found `isimip_id` is not already used in the ISIMIP Repository. Since `isimip-qc` works file-by-file this is rather slow and therefore only active when `--check-isimip-id` is set. Bulk checking of files can be done with different script.

Testing this PR needs the current `dev` branch of `isimip-utils`:

```
pip install git+https://ISI-MIP/isimip-utils@dev
```
